### PR TITLE
Prevent null string (and crash) on non-ASCII characters

### DIFF
--- a/objc/PdBase.m
+++ b/objc/PdBase.m
@@ -72,7 +72,14 @@ static void encodeList(NSArray *list) {
 		if ([object isKindOfClass:[NSNumber class]]) {
 			libpd_add_float([(NSNumber *)object floatValue]);
 		} else if ([object isKindOfClass:[NSString class]]) {
-			libpd_add_symbol([(NSString *)object cStringUsingEncoding:NSASCIIStringEncoding]);
+			if ([(NSString *)object canBeConvertedToEncoding:NSASCIIStringEncoding]) {
+        			libpd_add_symbol([(NSString *)object cStringUsingEncoding:NSASCIIStringEncoding]);
+      			} else {
+        			// If string contains non-ASCII characters, allow a lossy conversion (instead of returning null).
+        			NSData *data = [(NSString *)object dataUsingEncoding:NSASCIIStringEncoding allowLossyConversion:YES];
+        			NSString* newString = [[NSString alloc] initWithData:data encoding:NSASCIIStringEncoding];
+        			libpd_add_symbol([newString cStringUsingEncoding:NSASCIIStringEncoding]);
+      			}
 		} else {
 			NSLog(@"PdBase: message not supported. %@", [object class]);
 		}


### PR DESCRIPTION
Previously, any non-ASCII character in the NSString would yield a NULL from the cStringWithEncoding:, and then crash when that null pointer was dereferenced in m_class.c dogensym().
Now, if there are any non-ascii characters, the string is regenerated into ascii-able data.